### PR TITLE
Fix math.randomseed seeding potentially throwing

### DIFF
--- a/commands/1.lua
+++ b/commands/1.lua
@@ -4,7 +4,7 @@ movement = loadfile('movement.lua')
 m = movement()
 scriptName = "Script1"
 
-math.randomseed(os.clock()*100000000000)
+math.randomseed(os.time())
 
 
 run_daycare = {


### PR DESCRIPTION
This fixes a potential exception in the `math.randomseed()` call when `os.clock()` returns certain values. Using `os.time()` is the standard method anyways.

Example: For `os.clock() == 350.79`, `math.randomseed(350.79*100000000000)` will throw an exception saying `bad argument #1 to 'randomseed' (number has no integer representation)`.