### PR TITLE
To be safe, we should probably use the same longer wait for all instances of the jogger

### DIFF
--- a/commands/4.lua
+++ b/commands/4.lua
@@ -2172,7 +2172,7 @@ a = {
 {'use_move', 1},
 {'press_b', 11}, 
 {'use_move', 1},
-{'press_b', 4}, -- // gained 550 + 610
+{'press_b', 20}, -- // gained 550 + 610
 
 {'d', 2},
 {'r', 15},
@@ -4577,7 +4577,7 @@ a = {
 {'use_move', 1},
 {'press_b', 11}, 
 {'use_move', 1},
-{'press_b', 4}, -- // gained 550 + 610
+{'press_b', 20}, -- // gained 550 + 610
 
 {'u', 4}, -- leave rt 215
 {'w', 60},


### PR DESCRIPTION
There's two more instances of the jogger you changed the wait at in c0b8c0cbab7496dd257b1fb0560dedcb6fbb66c0 in response to https://github.com/KeeyanGhoreshi/PokemonPlatinumSingleSequence/issues/4#issuecomment-2440523291. I'm not sure whether it's necessary for those instances too but it probably doesn't hurt.

Also I'd have to double-check to be sure but it looked to me like the second Pokémon gives 601 EXP, not 610.