### PR TITLE
Handle case when berry on Vaporeon is not used in Cyrus fight

### DIFF
--- a/commands/7.lua
+++ b/commands/7.lua
@@ -2026,6 +2026,8 @@ a = {
 {'u', 5},
 {'press_a', 1},
 {'w', 240},
+{'press_a', 2},
+{'w', 240},
 {'press_b', 11}, -- done
 
 {'w', 60}, -- start the fight with golbat girl, do standard taunt/safeguard/surf combo to handle it
@@ -2511,7 +2513,7 @@ a = {
 {'l', 3},
 {'u', 7},
 {'w', 60}, -- done // 15-BeforeSaturn
-{'save', '16-BeforeShopping'},
+{'save', '16-BeforeSaturn'},
 
 {'x', 15}, -- put soft sand on hippowdon
 {'w', 60},


### PR DESCRIPTION
https://github.com/KeeyanGhoreshi/PokemonPlatinumSingleSequence/issues/4#issuecomment-2445680762

If the berry on Vaporeon is not used in the Cyrus fight, trying to give it a Sea Incense generates a 'Vaporeon is already holding Iapapa Berry, switch with Sea Incense?' prompt that needs to be handled. ~~If the berry was used this probably enters the Status screen but the following `press_b`s should cancel out of that and sync back up -- but I admit I haven't tested this case.~~ I tested it, it doesn't even get that far, it just enters the [Stats/Switch/Item/Cancel] menu and then cancels out. So yeah, works fine.

I also noticed an error in a savestate name that I fixed while I was here.